### PR TITLE
GitHub Actions: Validate MD Links

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,13 @@
+name: Check Markdown links
+
+on:
+  push
+  schedule:
+    - cron: "0 9 1 * *" # First of each month at 9 AM
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-# Configuration adapted from https://github.com/dkhamsing/awesome_bot
-
-language: ruby
-rvm: 2.4.1
-before_script: gem install awesome_bot
-script: awesome_bot *.md --allow-redirect --allow-ssl --allow-dupe --allow 202
-notifications:
-  email: false


### PR DESCRIPTION
Uses [markdown-link-check](https://github.com/marketplace/actions/markdown-link-check) to validate the links included in the main Markdown file are still valid.